### PR TITLE
removed button that said home as we already have the logo link

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,12 +7,6 @@
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0" aria-label="Options">
         <li class="nav-item">
-          <%= link_to (root_path), class: "nav-link d-flex justify-content-between align-items-center" do %>
-            Home
-            <i class="fa-solid fa-arrow-right fa-fw d-lg-none"></i>
-          <% end %>
-        </li>
-        <li class="nav-item">
           <%= link_to (venues_path), class: "nav-link d-flex justify-content-between align-items-center" do %>
             Venues
             <i class="fa-solid fa-arrow-right fa-fw d-lg-none"></i>


### PR DESCRIPTION
Literally one change, removing the button from the navbar for "home"

![image](https://user-images.githubusercontent.com/106918645/206531126-da1bb719-3c60-41d2-9892-aa5fadf2f555.png)

![image](https://user-images.githubusercontent.com/106918645/206531200-c3b0961b-e3f6-419a-9f58-d95fc485ca62.png)
